### PR TITLE
Add query to merge request diff versions

### DIFF
--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <PackageId>Apiiro.GitLabApiClient</PackageId>
-    <Version>0.1.8</Version>
+    <Version>0.1.9</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <PackageDescription>GitLabApiClient</PackageDescription>

--- a/src/GitLabApiClient/IMergeRequestsClient.cs
+++ b/src/GitLabApiClient/IMergeRequestsClient.cs
@@ -118,6 +118,6 @@ namespace GitLabApiClient
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <param name="mergeRequestIid">The Internal Merge Request Id.</param>
-        Task<IList<MergeRequestDiffVersion>> GetDiffVersions(ProjectId projectId, int mergeRequestIid);
+        Task<IList<MergeRequestDiffVersion>> GetDiffVersionsAsync(ProjectId projectId, int mergeRequestIid);
     }
 }

--- a/src/GitLabApiClient/IMergeRequestsClient.cs
+++ b/src/GitLabApiClient/IMergeRequestsClient.cs
@@ -112,5 +112,12 @@ namespace GitLabApiClient
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <param name="mergeRequestIid">The Internal Merge Request Id.</param>
         Task<IList<AwardEmoji>> GetAwardEmojisAsync(ProjectId projectId, int mergeRequestIid);
+
+        /// <summary>
+        /// Retrieves a list of all merge request diff versions for specified merge request.
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="mergeRequestIid">The Internal Merge Request Id.</param>
+        Task<IList<MergeRequestDiffVersion>> GetDiffVersions(ProjectId projectId, int mergeRequestIid);
     }
 }

--- a/src/GitLabApiClient/MergeRequestsClient.cs
+++ b/src/GitLabApiClient/MergeRequestsClient.cs
@@ -175,5 +175,13 @@ namespace GitLabApiClient
         public async Task<IList<AwardEmoji>> GetAwardEmojisAsync(ProjectId projectId, int mergeRequestIid) =>
             await _httpFacade.GetPagedList<AwardEmoji>($"projects/{projectId}/merge_requests/{mergeRequestIid}/award_emoji");
 
+        /// <summary>
+        /// Retrieves a list of all merge request diff versions for specified merge request.
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="mergeRequestIid">The Internal Merge Request Id.</param>
+        public async Task<IList<MergeRequestDiffVersion>> GetDiffVersions(ProjectId projectId, int mergeRequestIid) =>
+            await _httpFacade.GetPagedList<MergeRequestDiffVersion>($"projects/{projectId}/merge_requests/{mergeRequestIid}/versions");
+
     }
 }

--- a/src/GitLabApiClient/MergeRequestsClient.cs
+++ b/src/GitLabApiClient/MergeRequestsClient.cs
@@ -180,7 +180,7 @@ namespace GitLabApiClient
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <param name="mergeRequestIid">The Internal Merge Request Id.</param>
-        public async Task<IList<MergeRequestDiffVersion>> GetDiffVersions(ProjectId projectId, int mergeRequestIid) =>
+        public async Task<IList<MergeRequestDiffVersion>> GetDiffVersionsAsync(ProjectId projectId, int mergeRequestIid) =>
             await _httpFacade.GetPagedList<MergeRequestDiffVersion>($"projects/{projectId}/merge_requests/{mergeRequestIid}/versions");
 
     }

--- a/src/GitLabApiClient/Models/MergeRequests/Responses/MergeRequestDiffVersion.cs
+++ b/src/GitLabApiClient/Models/MergeRequests/Responses/MergeRequestDiffVersion.cs
@@ -1,0 +1,32 @@
+using System;
+using GitLabApiClient.Models.Users.Responses;
+using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models.MergeRequests.Responses;
+
+public class MergeRequestDiffVersion
+{
+    [JsonProperty("id")]
+    public int Id { get; set; }
+
+    [JsonProperty("head_commit_sha")]
+    public string HeadCommitSha { get; set; }
+
+    [JsonProperty("base_commit_sha")]
+    public string BaseCommitSha { get; set; }
+
+    [JsonProperty("start_commit_sha")]
+    public string StartCommitSha { get; set; }
+
+    [JsonProperty("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonProperty("merge_request_id")]
+    public int MergeRequestId { get; set; }
+
+    [JsonProperty("state")]
+    public string State { get; set; }
+
+    [JsonProperty("real_size")]
+    public int RealSize { get; set; }
+}


### PR DESCRIPTION
Related to LIM-5506.
In order to create a PR release, we need the base commit sha, which Gitlab only gives when querying for the merge request's versions.
Tested locally.