### PR TITLE
Change RealSize type from int to string

### DIFF
--- a/src/GitLabApiClient/Models/MergeRequests/Responses/MergeRequestDiffVersion.cs
+++ b/src/GitLabApiClient/Models/MergeRequests/Responses/MergeRequestDiffVersion.cs
@@ -28,5 +28,5 @@ public class MergeRequestDiffVersion
     public string State { get; set; }
 
     [JsonProperty("real_size")]
-    public int RealSize { get; set; }
+    public string RealSize { get; set; }
 }


### PR DESCRIPTION
Should fix LIM-6036.

I believe it didn't come up before because during my tests the real_size was a small number that was automatically converted, while in SoFi it's apparently "77+".