### PR TITLE
Add page options when getting groups

### DIFF
--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <PackageId>Apiiro.GitLabApiClient</PackageId>
-    <Version>0.1.24</Version>
+    <Version>0.1.25</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <PackageDescription>GitLabApiClient</PackageDescription>

--- a/src/GitLabApiClient/GroupsClient.cs
+++ b/src/GitLabApiClient/GroupsClient.cs
@@ -77,7 +77,7 @@ namespace GitLabApiClient
             options?.Invoke(queryOptions);
 
             string url = _queryBuilder.Build("groups", queryOptions);
-            return await _httpFacade.GetPagedList<Group>(url);
+            return await _httpFacade.GetPagedList<Group>(url, queryOptions.PageOptions);
         }
 
         /// <summary>

--- a/src/GitLabApiClient/Models/Groups/Requests/GroupsQueryOptions.cs
+++ b/src/GitLabApiClient/Models/Groups/Requests/GroupsQueryOptions.cs
@@ -5,7 +5,7 @@ namespace GitLabApiClient.Models.Groups.Requests
     /// <summary>
     /// Options for Groups listing
     /// </summary>
-    public class GroupsQueryOptions
+    public class GroupsQueryOptions : PagingQueryOptions
     {
         internal GroupsQueryOptions() { }
 


### PR DESCRIPTION
To verify the token is valid, we get the groups.
Some customers have over 70,000 groups, which take a long time to get.
This allows us to only get the first page, which is enough for us.

Related to LIM-17498