### PR TITLE
Changes around protected branches and approval rules calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package is managed with Nuget, in order to update it, follow the next steps
   * `cd src/GitLabApiClient`
   * `rm bin/Release/Apiiro.GitLabApiClient.*.nupkg`
   * `dotnet pack --configuration Release`
-  * `dotnet nuget push bin/Release/Apiiro.GitLabApiClient.*.nupkg --source "github" --skip-duplicate --no-symbols true --api-key <YOUR GITHUB PAT HERE>`
+  * `dotnet nuget push bin/Release/Apiiro.GitLabApiClient.*.nupkg --source "github" --skip-duplicate --no-symbols`
 
 
 [GitLabApiClient.csproj]: https://github.com/apiiro/GitLabApiClient/blob/master/src/GitLabApiClient/GitLabApiClient.csproj

--- a/src/GitLabApiClient/BranchClient.cs
+++ b/src/GitLabApiClient/BranchClient.cs
@@ -86,8 +86,8 @@ namespace GitLabApiClient
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <returns>List of protected branches.</returns>
-        public async Task<(RateLimitPagingInfo rateLimitPagingInfo, IList<ProtectedBranch>)> GetProtectedBranchesAsync(ProjectId projectId) =>
-            await _httpFacade.GetRateLimitPagedList<ProtectedBranch>($"projects/{projectId}/protected_branches", new PageOptions(Page: 1));
+        public async Task<(RateLimitInfo rateLimitInfo, IList<ProtectedBranch>)> GetProtectedBranchesAsync(ProjectId projectId) =>
+            await _httpFacade.GetWithRateLimitInfoAsync<IList<ProtectedBranch>>($"projects/{projectId}/protected_branches");
 
         /// <summary>
         /// Protect a branch
@@ -110,8 +110,9 @@ namespace GitLabApiClient
         /// Retrieves a list of Branches merge request approval rules from a project.
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="pageOptions">Page options <see cref="PageOptions"/></param>
         /// <returns>List of branches merge request approval rules.</returns>
-        public async Task<(RateLimitPagingInfo rateLimitPagingInfo, IList<ApprovalRules>)> GetMergeRequestApprovalRulesAsync(ProjectId projectId) =>
-            await _httpFacade.GetRateLimitPagedList<ApprovalRules>($"projects/{projectId}/approval_rules", new PageOptions(Page: 1));
+        public async Task<(RateLimitPagingInfo rateLimitPagingInfo, IList<ApprovalRules>)> GetMergeRequestApprovalRulesAsync(ProjectId projectId, PageOptions pageOptions) =>
+            await _httpFacade.GetRateLimitPagedList<ApprovalRules>($"projects/{projectId}/approval_rules", pageOptions);
     }
 }

--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <PackageId>Apiiro.GitLabApiClient</PackageId>
-    <Version>0.1.27</Version>
+    <Version>0.1.28</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <PackageDescription>GitLabApiClient</PackageDescription>

--- a/src/GitLabApiClient/IBranchClient.cs
+++ b/src/GitLabApiClient/IBranchClient.cs
@@ -60,7 +60,7 @@ namespace GitLabApiClient
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <returns>List of protected branches.</returns>
-        Task<(RateLimitPagingInfo rateLimitPagingInfo, IList<ProtectedBranch>)> GetProtectedBranchesAsync(ProjectId projectId);
+        Task<(RateLimitInfo rateLimitInfo, IList<ProtectedBranch>)> GetProtectedBranchesAsync(ProjectId projectId);
 
         /// <summary>
         /// Protect a branch
@@ -81,7 +81,8 @@ namespace GitLabApiClient
         /// Retrieves a list of Branches merge request approval rules from a project.
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="pageOptions">Page options <see cref="PageOptions"/></param>
         /// <returns>List of branches merge request approval rules.</returns>
-        Task<(RateLimitPagingInfo rateLimitPagingInfo, IList<ApprovalRules>)> GetMergeRequestApprovalRulesAsync(ProjectId projectId);
+        Task<(RateLimitPagingInfo rateLimitPagingInfo, IList<ApprovalRules>)> GetMergeRequestApprovalRulesAsync(ProjectId projectId, PageOptions pageOptions);
     }
 }

--- a/src/GitLabApiClient/Internal/Http/GitLabApiPagedRequestor.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabApiPagedRequestor.cs
@@ -21,28 +21,7 @@ namespace GitLabApiClient.Internal.Http
             var (results, headers) = await _requestor.GetWithHeaders<IList<T>>(
                 GetPagedUrl(url, pageOptions.Page, pageOptions.ItemsPerPage));
 
-
-            var rateLimitPagingInfo = new RateLimitPagingInfo
-            {
-                PagingInfo = new PagingInfo
-                {
-                    NextPage = headers.GetFirstHeaderValueOrDefault<int>("X-Next-Page"),
-                    Page = headers.GetFirstHeaderValueOrDefault<int>("X-Page"),
-                    PerPage = headers.GetFirstHeaderValueOrDefault<int>("X-Per-Page"),
-                    PrevPage = headers.GetFirstHeaderValueOrDefault<int>("X-Prev-Page"),
-                    Total = headers.GetFirstHeaderValueOrDefault<int>("X-Total"),
-                    TotalPages = headers.GetFirstHeaderValueOrDefault<int>("X-Total-Pages"),
-                },
-                RateLimitInfo = new RateLimitInfo
-                {
-                    RateLimitObserved = headers.GetFirstHeaderValueOrDefault<int>("RateLimit-Observed"),
-                    RateLimitRemaining = headers.GetFirstHeaderValueOrDefault<int>("RateLimit-Remaining"),
-                    RateLimitResetTime = headers.GetFirstHeaderValueOrDefault<DateTime>("RateLimit-ResetTime"),
-                    RateLimitLimit = headers.GetFirstHeaderValueOrDefault<int>("RateLimit-Limit"),
-                }
-            };
-
-            return new (rateLimitPagingInfo, results);
+            return new ValueTuple<RateLimitPagingInfo, IList<T>>(RateLimitPagingInfo.FromHeaders(headers), results);
         }
 
         public async Task<IList<T>> GetPagedList<T>(string url, PageOptions pageOptions)

--- a/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
@@ -66,6 +66,12 @@ namespace GitLabApiClient.Internal.Http
         public Task<(RateLimitPagingInfo rateLimitPagingInfo, IList<T>)> GetRateLimitPagedList<T>(string uri, PageOptions pageOptions) =>
             _pagedRequestor.GetRateLimitPagedList<T>(uri, pageOptions);
 
+        public async Task<(RateLimitInfo rateLimitInfo, T)> GetWithRateLimitInfoAsync<T>(string uri)
+        {
+            var (item, headers) = await _requestor.GetWithHeaders<T>(uri);
+            return (RateLimitInfo.FromHeaders(headers), item);
+        }
+
         public Task<IList<T>> GetPagedList<T>(string uri, PageOptions pageOptions = null) =>
             _pagedRequestor.GetPagedList<T>(uri, pageOptions);
 

--- a/src/GitLabApiClient/Models/PagingInfo.cs
+++ b/src/GitLabApiClient/Models/PagingInfo.cs
@@ -1,11 +1,25 @@
+using System.Net.Http.Headers;
+using GitLabApiClient.Internal.Http;
+
 namespace GitLabApiClient.Models;
 
 public class PagingInfo
 {
-    public int? NextPage { get; set; }
-    public int? Page { get; set; }
-    public int? PerPage { get; set; }
-    public int? PrevPage { get; set; }
-    public int? Total { get; set; }
-    public int? TotalPages { get; set; }
+    public int? NextPage { get; init; }
+    public int? Page { get; init; }
+    public int? PerPage { get; init; }
+    public int? PrevPage { get; init; }
+    public int? Total { get; init; }
+    public int? TotalPages { get; init; }
+
+    public static PagingInfo FromHeaders(HttpResponseHeaders headers)
+        => new()
+        {
+            NextPage = headers.GetFirstHeaderValueOrDefault<int?>("X-Next-Page"),
+            Page = headers.GetFirstHeaderValueOrDefault<int?>("X-Page"),
+            PerPage = headers.GetFirstHeaderValueOrDefault<int?>("X-Per-Page"),
+            PrevPage = headers.GetFirstHeaderValueOrDefault<int?>("X-Prev-Page"),
+            Total = headers.GetFirstHeaderValueOrDefault<int?>("X-Total"),
+            TotalPages = headers.GetFirstHeaderValueOrDefault<int?>("X-Total-Pages")
+        };
 }

--- a/src/GitLabApiClient/Models/RateLimitInfo.cs
+++ b/src/GitLabApiClient/Models/RateLimitInfo.cs
@@ -1,11 +1,22 @@
 using System;
+using System.Net.Http.Headers;
+using GitLabApiClient.Internal.Http;
 
 namespace GitLabApiClient.Models;
 
 public class RateLimitInfo
 {
-    public int? RateLimitObserved { get; set; }
-    public int? RateLimitRemaining { get; set; }
-    public DateTime? RateLimitResetTime { get; set; }
-    public int? RateLimitLimit { get; set; }
+    public int? RateLimitObserved { get; init; }
+    public int? RateLimitRemaining { get; init; }
+    public DateTime? RateLimitResetTime { get; init; }
+    public int? RateLimitLimit { get; init; }
+
+    public static RateLimitInfo FromHeaders(HttpResponseHeaders headers)
+        => new()
+        {
+            RateLimitObserved = headers.GetFirstHeaderValueOrDefault<int?>("RateLimit-Observed"),
+            RateLimitRemaining = headers.GetFirstHeaderValueOrDefault<int?>("RateLimit-Remaining"),
+            RateLimitResetTime = headers.GetFirstHeaderValueOrDefault<DateTime?>("RateLimit-ResetTime"),
+            RateLimitLimit = headers.GetFirstHeaderValueOrDefault<int?>("RateLimit-Limit")
+        };
 }

--- a/src/GitLabApiClient/Models/RateLimitPagingInfo.cs
+++ b/src/GitLabApiClient/Models/RateLimitPagingInfo.cs
@@ -1,9 +1,19 @@
+using System.Net.Http.Headers;
 
 namespace GitLabApiClient.Models;
 
 public class RateLimitPagingInfo
 {
-    public PagingInfo PagingInfo { get; set; }
+    public RateLimitPagingInfo(PagingInfo pagingInfo, RateLimitInfo rateLimitInfo)
+    {
+        PagingInfo = pagingInfo;
+        RateLimitInfo = rateLimitInfo;
+    }
 
-    public RateLimitInfo RateLimitInfo { get; set; }
+    public PagingInfo PagingInfo { get; init; }
+
+    public RateLimitInfo RateLimitInfo { get; init; }
+
+    public static RateLimitPagingInfo FromHeaders(HttpResponseHeaders headers)
+        => new(PagingInfo.FromHeaders(headers), RateLimitInfo.FromHeaders(headers));
 }


### PR DESCRIPTION
Two issues:
1. Protected branches doesn't support pagination but we still call it with page equals one and return a pagination info in the response, this is confusing (reference is [List protected branches](https://docs.gitlab.com/ee/api/protected_branches.html#list-protected-branches) documentation)
2. Approval rules does support pagination but we currently only pull the first page with hardcoded value (reference is [Get project-level rules](https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-project-level-rules) documentation)