### PR TITLE
Fix headers conversion to nullable type

### DIFF
--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <PackageId>Apiiro.GitLabApiClient</PackageId>
-    <Version>0.1.28</Version>
+    <Version>0.1.29</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <PackageDescription>GitLabApiClient</PackageDescription>

--- a/src/GitLabApiClient/Internal/Http/GitLabApiPagedRequestor.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabApiPagedRequestor.cs
@@ -112,17 +112,25 @@ namespace GitLabApiClient.Internal.Http
 
     internal static class HttpResponseHeadersExtensions
     {
-        public static T GetFirstHeaderValueOrDefault<T>(
-            this HttpResponseHeaders headers,
-            string headerKey)
+        public static T GetFirstHeaderValueOrDefault<T>(this HttpResponseHeaders headers, string headerKey)
+            => headers.TryGetFirstHeaderValue<T>(headerKey, out var result) ? result : default;
+
+        public static int? GetFirstHeaderIntValueOrNull(this HttpResponseHeaders headers, string headerKey)
+            => headers.TryGetFirstHeaderValue(headerKey, out int result) ? result : null;
+
+        public static DateTime? GetFirstHeaderDateTimeValueOrNull(this HttpResponseHeaders headers, string headerKey)
+            => headers.TryGetFirstHeaderValue(headerKey, out DateTime result) ? result : null;
+
+        private static bool TryGetFirstHeaderValue<T>(this HttpHeaders headers, string headerKey, out T result)
         {
-            var toReturn = default(T);
+            if (headers.TryGetValues(headerKey, out var headerValues) && headerValues.FirstOrDefault() is { } valueString && !valueString.IsNullOrEmpty())
+            {
+                result = (T)Convert.ChangeType(valueString, typeof(T));
+                return true;
+            }
 
-            if (!headers.TryGetValues(headerKey, out var headerValues))
-                return toReturn;
-
-            string valueString = headerValues.FirstOrDefault();
-            return valueString.IsNullOrEmpty() ? toReturn : (T)Convert.ChangeType(valueString, typeof(T));
+            result = default;
+            return false;
         }
     }
 }

--- a/src/GitLabApiClient/Models/PagingInfo.cs
+++ b/src/GitLabApiClient/Models/PagingInfo.cs
@@ -15,11 +15,11 @@ public class PagingInfo
     public static PagingInfo FromHeaders(HttpResponseHeaders headers)
         => new()
         {
-            NextPage = headers.GetFirstHeaderValueOrDefault<int?>("X-Next-Page"),
-            Page = headers.GetFirstHeaderValueOrDefault<int?>("X-Page"),
-            PerPage = headers.GetFirstHeaderValueOrDefault<int?>("X-Per-Page"),
-            PrevPage = headers.GetFirstHeaderValueOrDefault<int?>("X-Prev-Page"),
-            Total = headers.GetFirstHeaderValueOrDefault<int?>("X-Total"),
-            TotalPages = headers.GetFirstHeaderValueOrDefault<int?>("X-Total-Pages")
+            NextPage = headers.GetFirstHeaderIntValueOrNull("X-Next-Page"),
+            Page = headers.GetFirstHeaderIntValueOrNull("X-Page"),
+            PerPage = headers.GetFirstHeaderIntValueOrNull("X-Per-Page"),
+            PrevPage = headers.GetFirstHeaderIntValueOrNull("X-Prev-Page"),
+            Total = headers.GetFirstHeaderIntValueOrNull("X-Total"),
+            TotalPages = headers.GetFirstHeaderIntValueOrNull("X-Total-Pages")
         };
 }

--- a/src/GitLabApiClient/Models/RateLimitInfo.cs
+++ b/src/GitLabApiClient/Models/RateLimitInfo.cs
@@ -14,9 +14,9 @@ public class RateLimitInfo
     public static RateLimitInfo FromHeaders(HttpResponseHeaders headers)
         => new()
         {
-            RateLimitObserved = headers.GetFirstHeaderValueOrDefault<int?>("RateLimit-Observed"),
-            RateLimitRemaining = headers.GetFirstHeaderValueOrDefault<int?>("RateLimit-Remaining"),
-            RateLimitResetTime = headers.GetFirstHeaderValueOrDefault<DateTime?>("RateLimit-ResetTime"),
-            RateLimitLimit = headers.GetFirstHeaderValueOrDefault<int?>("RateLimit-Limit")
+            RateLimitObserved = headers.GetFirstHeaderIntValueOrNull("RateLimit-Observed"),
+            RateLimitRemaining = headers.GetFirstHeaderIntValueOrNull("RateLimit-Remaining"),
+            RateLimitResetTime = headers.GetFirstHeaderDateTimeValueOrNull("RateLimit-ResetTime"),
+            RateLimitLimit = headers.GetFirstHeaderIntValueOrNull("RateLimit-Limit")
         };
 }

--- a/test/GitLabApiClient.Test/Internal/Http/HttpResponseHeadersExtensionsTest.cs
+++ b/test/GitLabApiClient.Test/Internal/Http/HttpResponseHeadersExtensionsTest.cs
@@ -9,7 +9,7 @@ namespace GitLabApiClient.Test.Internal.Http
 {
     public class HttpResponseHeadersExtensionsTest
     {
-        private HttpResponseHeaders GetTestHeaders()
+        private static HttpResponseHeaders GetTestHeaders()
         {
             var response = new HttpResponseMessage(HttpStatusCode.Created);
             response.Headers.Add("X-Fifty-Five", "55");
@@ -21,7 +21,7 @@ namespace GitLabApiClient.Test.Internal.Http
         [Fact]
         public void GetFirstHeaderValueOrDefault_WithEmptyValue_ReturnDefaultValue()
         {
-            int expected = 0;
+            const int expected = 0;
             var sut = GetTestHeaders();
 
             int result = sut.GetFirstHeaderValueOrDefault<int>("X-Empty");
@@ -32,7 +32,7 @@ namespace GitLabApiClient.Test.Internal.Http
         [Fact]
         public void GetFirstHeaderValueOrDefault_WithNotExistingKey_ReturnDefaultValue()
         {
-            int expected = 0;
+            const int expected = 0;
             var sut = GetTestHeaders();
 
             int result = sut.GetFirstHeaderValueOrDefault<int>("X-Not-Exists");
@@ -43,12 +43,44 @@ namespace GitLabApiClient.Test.Internal.Http
         [Fact]
         public void GetFirstHeaderValueOrDefault_WithValue_ReturnValue()
         {
-            int expected = 55;
+            const int expected = 55;
             var sut = GetTestHeaders();
 
             int result = sut.GetFirstHeaderValueOrDefault<int>("X-Fifty-Five");
 
             result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetFirstHeaderIntValueOrNull_WithEmptyValue_ReturnNull()
+        {
+            var sut = GetTestHeaders();
+
+            int? result = sut.GetFirstHeaderIntValueOrNull("X-Empty");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetFirstHeaderIntValueOrNull_WithNotExistingKey_ReturnNull()
+        {
+            var sut = GetTestHeaders();
+
+            int? result = sut.GetFirstHeaderIntValueOrNull("X-Not-Exists");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetFirstHeaderIntValueOrNull_WithValue_ReturnValue()
+        {
+            const int expectedResult = 55;
+            var sut = GetTestHeaders();
+
+            int? result = sut.GetFirstHeaderIntValueOrNull("X-Fifty-Five");
+
+            Assert.True(result.HasValue);
+            result.Value.Should().Be(expectedResult);
         }
     }
 }


### PR DESCRIPTION
When extracting header values, conversion to nullable types fails with the following error message:
```
System.InvalidCastException: Invalid cast from 'System.String' to 'System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]'.
   at System.Convert.DefaultToType(IConvertible value, Type targetType, IFormatProvider provider)
   at System.String.System.IConvertible.ToType(Type type, IFormatProvider provider)
   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at System.Convert.ChangeType(Object value, Type conversionType)
   at GitLabApiClient.Internal.Http.HttpResponseHeadersExtensions.GetFirstHeaderValueOrDefault[T](HttpResponseHeaders headers, String headerKey)
   at GitLabApiClient.Models.RateLimitInfo.FromHeaders(HttpResponseHeaders headers)
```