### PR TITLE
Add HttpClient injection support to GitLabClient

### DIFF
--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <PackageId>Apiiro.GitLabApiClient</PackageId>
-    <Version>0.1.43</Version>
+    <Version>0.1.44</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <PackageDescription>GitLabApiClient</PackageDescription>

--- a/src/GitLabApiClient/GitLabClient.cs
+++ b/src/GitLabApiClient/GitLabClient.cs
@@ -29,7 +29,7 @@ namespace GitLabApiClient
         {
             Guard.NotEmpty(hostUrl, nameof(hostUrl));
             Guard.NotNull(authenticationToken, nameof(authenticationToken));
-            HostUrl = FixBaseUrl(hostUrl);
+            HostUrl = FixBaseUrl(hostUrl, false);
 
             var jsonSerializer = new RequestsJsonSerializer();
 
@@ -56,13 +56,7 @@ namespace GitLabApiClient
             Guard.NotNull(httpClient.BaseAddress, nameof(httpClient.BaseAddress));
             Guard.NotNull(authenticationToken, nameof(authenticationToken));
 
-            var baseAddress = httpClient.BaseAddress!.ToString().TrimEnd('/');
-            if (!baseAddress.EndsWith("/api/v4", StringComparison.OrdinalIgnoreCase))
-                throw new ArgumentException(
-                    "HttpClient.BaseAddress must point to the GitLab API v4 endpoint (e.g. https://gitlab.example.com/api/v4/).",
-                    nameof(httpClient));
-
-            HostUrl = baseAddress + "/";
+            HostUrl = FixBaseUrl(httpClient.BaseAddress!.ToString(), true);
 
             var jsonSerializer = new RequestsJsonSerializer();
 
@@ -229,12 +223,21 @@ namespace GitLabApiClient
 
         public async Task<Metadata> GetMetadata() => await _httpFacade.Get<Metadata>("metadata");
 
-        public static string FixBaseUrl(string url)
+        public static string FixBaseUrl(string url, bool throwIfNotValid)
         {
             url = url.TrimEnd('/');
 
             if (!url.EndsWith("/api/v4", StringComparison.OrdinalIgnoreCase))
+            {
+                if (throwIfNotValid)
+                {
+                    throw new ArgumentException(
+                        "Host url must point to the GitLab API v4 endpoint (e.g. https://gitlab.example.com/api/v4/).",
+                        nameof(url));
+                }
+
                 url += "/api/v4";
+            }
 
             return url + "/";
         }

--- a/src/GitLabApiClient/GitLabClient.cs
+++ b/src/GitLabApiClient/GitLabClient.cs
@@ -40,6 +40,39 @@ namespace GitLabApiClient
                 httpMessageHandler,
                 clientTimeout);
 
+            InitializeClients();
+        }
+
+        /// <summary>
+        /// Creates a new instance of the GitLab API v4 client using a pre-configured <see cref="HttpClient"/>.
+        /// The provided HttpClient must have its BaseAddress set to the GitLab API v4 endpoint
+        /// (e.g. https://gitlab.example.com/api/v4/).
+        /// </summary>
+        /// <param name="httpClient">A pre-configured HttpClient instance. Must have BaseAddress set.</param>
+        /// <param name="authenticationToken">Personal access token. Obtained from GitLab profile settings.</param>
+        public GitLabClient(HttpClient httpClient, string authenticationToken = "")
+        {
+            Guard.NotNull(httpClient, nameof(httpClient));
+            Guard.NotNull(httpClient.BaseAddress, nameof(httpClient.BaseAddress));
+            Guard.NotNull(authenticationToken, nameof(authenticationToken));
+
+            var baseAddress = httpClient.BaseAddress!.ToString().TrimEnd('/');
+            if (!baseAddress.EndsWith("/api/v4", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException(
+                    "HttpClient.BaseAddress must point to the GitLab API v4 endpoint (e.g. https://gitlab.example.com/api/v4/).",
+                    nameof(httpClient));
+
+            HostUrl = baseAddress + "/";
+
+            var jsonSerializer = new RequestsJsonSerializer();
+
+            _httpFacade = new GitLabHttpFacade(httpClient, jsonSerializer, authenticationToken);
+
+            InitializeClients();
+        }
+
+        private void InitializeClients()
+        {
             var projectQueryBuilder = new ProjectsQueryBuilder();
             var projectIssueNotesQueryBuilder = new ProjectIssueNotesQueryBuilder();
             var projectMergeRequestsNotesQueryBuilder = new ProjectMergeRequestsNotesQueryBuilder();
@@ -85,92 +118,92 @@ namespace GitLabApiClient
         /// <summary>
         /// Access GitLab's issues API.
         /// </summary>
-        public IIssuesClient Issues { get; }
+        public IIssuesClient Issues { get; private set; }
 
         /// <summary>
         /// Access GitLab's uploads API.
         /// </summary>
-        public IUploadsClient Uploads { get; }
+        public IUploadsClient Uploads { get; private set; }
 
         /// <summary>
         /// Access GitLab's merge requests API.
         /// </summary>
-        public IMergeRequestsClient MergeRequests { get; }
+        public IMergeRequestsClient MergeRequests { get; private set; }
 
         /// <summary>
         /// Access GitLab's projects API.
         /// </summary>
-        public IProjectsClient Projects { get; }
+        public IProjectsClient Projects { get; private set; }
 
         /// <summary>
         /// Access GitLab's users API.
         /// </summary>
-        public IUsersClient Users { get; }
+        public IUsersClient Users { get; private set; }
 
         /// <summary>
         /// Access GitLab's groups API.
         /// </summary>
-        public IGroupsClient Groups { get; }
+        public IGroupsClient Groups { get; private set; }
 
         /// <summary>
         /// Access GitLab's branches API.
         /// </summary>
-        public IBranchClient Branches { get; }
+        public IBranchClient Branches { get; private set; }
 
         /// <summary>
         /// Access GitLab's release API.
         /// </summary>
-        public IReleaseClient Releases { get; }
+        public IReleaseClient Releases { get; private set; }
 
         /// <summary>
         /// Access GitLab's tags API.
         /// </summary>
-        public ITagClient Tags { get; }
+        public ITagClient Tags { get; private set; }
 
         /// <summary>
         /// Access GitLab's webhook API.
         /// </summary>
-        public IWebhookClient Webhooks { get; }
+        public IWebhookClient Webhooks { get; private set; }
 
         /// <summary>
         /// Access GitLab's commits API.
         /// </summary>
-        public ICommitsClient Commits { get; }
+        public ICommitsClient Commits { get; private set; }
 
         /// <summary>
         /// Access GitLab's trees API.
         /// </summary>
-        public ITreesClient Trees { get; }
+        public ITreesClient Trees { get; private set; }
 
         /// <summary>
         /// Access GitLab's files API.
         /// </summary>
-        public IFilesClient Files { get; }
+        public IFilesClient Files { get; private set; }
 
         /// <summary>
         /// Access GitLab's Markdown API.
         /// </summary>
-        public IMarkdownClient Markdown { get; }
+        public IMarkdownClient Markdown { get; private set; }
 
         /// <summary>
         /// Acess GitLab's Pipeline API.
         /// </summary>
-        public IPipelineClient Pipelines { get; }
+        public IPipelineClient Pipelines { get; private set; }
 
         /// <summary>
         /// Access GitLab's Runners API.
         /// </summary>
-        public IRunnersClient Runners { get; }
+        public IRunnersClient Runners { get; private set; }
 
         /// <summary>
         /// Access GitLab's ToDo-List API.
         /// </summary>
-        public IToDoListClient ToDoList { get; }
+        public IToDoListClient ToDoList { get; private set; }
 
         /// <summary>
         /// Provides a client connection to make rest requests to HTTP endpoints.
         /// </summary>
-        public ConnectionClient Connection { get; }
+        public ConnectionClient Connection { get; private set; }
 
         /// <summary>
         /// Host address of GitLab instance. For example https://gitlab.example.com or https://gitlab.example.com/api/v4/.
@@ -196,7 +229,7 @@ namespace GitLabApiClient
 
         public async Task<Metadata> GetMetadata() => await _httpFacade.Get<Metadata>("metadata");
 
-        private static string FixBaseUrl(string url)
+        public static string FixBaseUrl(string url)
         {
             url = url.TrimEnd('/');
 

--- a/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
@@ -31,7 +31,23 @@ namespace GitLabApiClient.Internal.Http
         }
 
         public GitLabHttpFacade(string hostUrl, RequestsJsonSerializer jsonSerializer, string authenticationToken = "", HttpMessageHandler httpMessageHandler = null, TimeSpan? clientTimeout = null) :
-            this(hostUrl, jsonSerializer, httpMessageHandler, clientTimeout)
+            this(hostUrl, jsonSerializer, httpMessageHandler, clientTimeout) =>
+            ConfigureAuthentication(authenticationToken);
+
+        public GitLabHttpFacade(RequestsJsonSerializer jsonSerializer, HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            Setup(jsonSerializer);
+        }
+
+        public GitLabHttpFacade(HttpClient httpClient, RequestsJsonSerializer jsonSerializer, string authenticationToken)
+        {
+            _httpClient = httpClient;
+            ConfigureAuthentication(authenticationToken);
+            Setup(jsonSerializer);
+        }
+
+        private void ConfigureAuthentication(string authenticationToken)
         {
             switch (authenticationToken.Length)
             {
@@ -46,12 +62,6 @@ namespace GitLabApiClient.Internal.Http
                 default:
                     throw new ArgumentException("Unsupported authentication token provide, please private an oauth or private token");
             }
-        }
-
-        public GitLabHttpFacade(RequestsJsonSerializer jsonSerializer, HttpClient httpClient)
-        {
-            _httpClient = httpClient;
-            Setup(jsonSerializer);
         }
 
         private void Setup(RequestsJsonSerializer jsonSerializer)


### PR DESCRIPTION
Closes LIM-38300

## Summary

- Add a new `GitLabClient` constructor that accepts a pre-configured `HttpClient`, enabling callers to control HTTP protocol version (e.g. HTTP/2) and connection lifecycle
- Extract authentication logic in `GitLabHttpFacade` into a reusable `ConfigureAuthentication` method
- Extract shared client initialization into `InitializeClients()` to avoid duplication across constructors
- Make `FixBaseUrl` public so callers can normalize host URLs before setting `HttpClient.BaseAddress`
- Add validation that injected `HttpClient.BaseAddress` points to the GitLab API v4 endpoint
- Bump package version to `0.1.44`

## Notes

- The original constructor remains fully backward-compatible
- Properties changed from `{ get; }` to `{ get; private set; }` to support the extracted `InitializeClients()` method (safe since the class is `sealed`)
- Caller-side integration in `lim` repo will be a separate PR


Made with [Cursor](https://cursor.com)