### PR TITLE
Fix WebhookClient.CreateAsync array response handling

### DIFF
--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <PackageId>Apiiro.GitLabApiClient</PackageId>
-    <Version>0.1.44</Version>
+    <Version>0.1.45</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <PackageDescription>GitLabApiClient</PackageDescription>

--- a/src/GitLabApiClient/WebhookClient.cs
+++ b/src/GitLabApiClient/WebhookClient.cs
@@ -40,7 +40,9 @@ namespace GitLabApiClient
         }
 
         /// <summary>
-        /// Create new webhook
+        /// Create new webhook.
+        /// Some GitLab versions return a JSON array from POST /projects/:id/hooks
+        /// instead of a single object. We deserialize as JToken to handle both formats.
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <param name="request">Create hook request.</param>

--- a/src/GitLabApiClient/WebhookClient.cs
+++ b/src/GitLabApiClient/WebhookClient.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GitLabApiClient.Internal.Http;
 using GitLabApiClient.Internal.Paths;
 using GitLabApiClient.Models.Projects.Responses;
 using GitLabApiClient.Models.Webhooks.Requests;
 using GitLabApiClient.Models.Webhooks.Responses;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace GitLabApiClient
 {
@@ -42,8 +45,16 @@ namespace GitLabApiClient
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <param name="request">Create hook request.</param>
         /// <returns>newly created hook</returns>
-        public async Task<Webhook> CreateAsync(ProjectId projectId, CreateWebhookRequest request) =>
-            await _httpFacade.Post<Webhook>($"projects/{projectId}/hooks", request);
+        public async Task<Webhook> CreateAsync(ProjectId projectId, CreateWebhookRequest request)
+        {
+            var token = await _httpFacade.Post<JToken>($"projects/{projectId}/hooks", request);
+            return token switch
+            {
+                JArray array => array.FirstOrDefault()?.ToObject<Webhook>(),
+                JObject obj => obj.ToObject<Webhook>(),
+                _ => null
+            };
+        }
 
         /// <summary>
         /// Delete a webhook


### PR DESCRIPTION
## Summary
- GitLab API now returns a JSON array from `POST /projects/:id/hooks` instead of a single object
- This causes `JsonSerializationException` in `WebhookClient.CreateAsync` which expects a single `Webhook`
- Fix deserializes as `JToken` first, then handles both array and single object responses
- Bumps version to 0.1.45

**Note:** CI fixes are in a separate PR: #46

## Test plan
- [ ] Deploy to CI staging and verify webhook creation no longer throws exceptions
- [ ] Verify existing webhook operations (get, delete, update) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)