### PR TITLE
Revert webhook array response handling

### DIFF
--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <PackageId>Apiiro.GitLabApiClient</PackageId>
-    <Version>0.1.45</Version>
+    <Version>0.1.44</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <PackageDescription>GitLabApiClient</PackageDescription>

--- a/src/GitLabApiClient/WebhookClient.cs
+++ b/src/GitLabApiClient/WebhookClient.cs
@@ -1,13 +1,10 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GitLabApiClient.Internal.Http;
 using GitLabApiClient.Internal.Paths;
 using GitLabApiClient.Models.Projects.Responses;
 using GitLabApiClient.Models.Webhooks.Requests;
 using GitLabApiClient.Models.Webhooks.Responses;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace GitLabApiClient
 {
@@ -40,23 +37,13 @@ namespace GitLabApiClient
         }
 
         /// <summary>
-        /// Create new webhook.
-        /// Some GitLab versions return a JSON array from POST /projects/:id/hooks
-        /// instead of a single object. We deserialize as JToken to handle both formats.
+        /// Create new webhook
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <param name="request">Create hook request.</param>
         /// <returns>newly created hook</returns>
-        public async Task<Webhook> CreateAsync(ProjectId projectId, CreateWebhookRequest request)
-        {
-            var token = await _httpFacade.Post<JToken>($"projects/{projectId}/hooks", request);
-            return token switch
-            {
-                JArray array => array.FirstOrDefault()?.ToObject<Webhook>(),
-                JObject obj => obj.ToObject<Webhook>(),
-                _ => null
-            };
-        }
+        public async Task<Webhook> CreateAsync(ProjectId projectId, CreateWebhookRequest request) =>
+            await _httpFacade.Post<Webhook>($"projects/{projectId}/hooks", request);
 
         /// <summary>
         /// Delete a webhook


### PR DESCRIPTION
## Summary
- Reverts PR #45 which added array handling in `WebhookClient.CreateAsync`
- The root cause was the connectors simulator returning an array instead of a single object for `POST /projects/:id/hooks`
- The simulator was fixed in [simulator#155](https://github.com/apiiro/simulator/pull/155), so this client-side workaround is no longer needed
- Reverts version back to 0.1.44

## Test plan
- [x] Verify CI webhook creation still works with the simulator fix in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)